### PR TITLE
[CHAT-1] WebSocketServer 정의

### DIFF
--- a/websocket-gateway/src/main/kotlin/com/example/websocketgateway/websocket/WebSocketHandler.kt
+++ b/websocket-gateway/src/main/kotlin/com/example/websocketgateway/websocket/WebSocketHandler.kt
@@ -1,0 +1,51 @@
+package com.example.websocketgateway.websocket
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.SimpleChannelInboundHandler
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame
+import io.netty.handler.codec.http.websocketx.WebSocketFrame
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler
+
+class WebSocketHandler : SimpleChannelInboundHandler<WebSocketFrame>() {
+    private val logger = KotlinLogging.logger {}
+
+    override fun channelActive(ctx: ChannelHandlerContext) {
+        logger.info { "[WebSocketHandler][Active] (client: ${ctx.channel().remoteAddress()})" }
+    }
+
+    override fun channelInactive(ctx: ChannelHandlerContext) {
+        logger.info { "[WebSocketHandler][InActive] (client: ${ctx.channel().remoteAddress()})" }
+    }
+
+    override fun channelRead0(
+        ctx: ChannelHandlerContext,
+        frame: WebSocketFrame,
+    ) {
+        if (frame is TextWebSocketFrame) {
+            val request = frame.text()
+            logger.info { "[WebSocketHandler][TextFrame] (request: $request)" }
+            ctx.channel().writeAndFlush(TextWebSocketFrame("echo: $request"))
+        }
+    }
+
+    override fun userEventTriggered(
+        ctx: ChannelHandlerContext,
+        evt: Any,
+    ) {
+        if (evt is WebSocketServerProtocolHandler.HandshakeComplete) {
+            logger.info { "[WebSocketHandler][HandshakeComplete] (client: ${ctx.channel().remoteAddress()}, uri:${evt.requestUri()})" }
+            /**
+             * TODO: Authentication 검증하기 (Token 검증) && HttpServer에 Sta지e전파 어떻게하
+             */
+        }
+    }
+
+    override fun exceptionCaught(
+        ctx: ChannelHandlerContext,
+        cause: Throwable,
+    ) {
+        logger.error(cause) { "[WebSocketHandler][ErrorCaught]" }
+        ctx.close()
+    }
+}

--- a/websocket-gateway/src/main/kotlin/com/example/websocketgateway/websocket/WebSocketServer.kt
+++ b/websocket-gateway/src/main/kotlin/com/example/websocketgateway/websocket/WebSocketServer.kt
@@ -1,0 +1,53 @@
+package com.example.websocketgateway.websocket
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.netty.bootstrap.ServerBootstrap
+import io.netty.channel.Channel
+import io.netty.channel.ChannelOption
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.nio.NioServerSocketChannel
+import io.netty.handler.logging.LogLevel
+import io.netty.handler.logging.LoggingHandler
+
+class WebSocketServer(private val port: Int) {
+    private val bossGroup = NioEventLoopGroup(1)
+    private val workerGroup = NioEventLoopGroup()
+    private var channel: Channel? = null
+
+    fun start() {
+        logger.info { "[WebSocketServer][Start] (port:$port)" }
+        try {
+            val bootStrap = ServerBootstrap()
+            bootStrap.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel::class.java)
+                .handler(LoggingHandler(LogLevel.DEBUG))
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childOption(ChannelOption.TCP_NODELAY, true)
+                .childHandler(WebSocketServerPipeLineInitializer())
+
+            channel = bootStrap.bind(port).sync().channel()
+            logger.info { "[WebSocketServer][Started] (port:$port)" }
+
+            channel?.closeFuture()?.sync()
+        } catch (e: Exception) {
+            logger.error(e) { "[WebSocketServer][Start][Fail] (port:$port)" }
+            stop()
+        }
+    }
+
+    fun stop() {
+        logger.info { "[WebSocketServer][Stop] (port:$port)" }
+        try {
+            channel?.close()?.sync()
+            bossGroup.shutdownGracefully()
+            workerGroup.shutdownGracefully()
+            logger.info { "[WebSocketServer][Stopped] (port:$port)" }
+        } catch (e: Exception) {
+            logger.error(e) { "[WebSocketServer][Stop][Fail] (port:$port)" }
+        }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}

--- a/websocket-gateway/src/main/kotlin/com/example/websocketgateway/websocket/WebSocketServerPipeLineInitializer.kt
+++ b/websocket-gateway/src/main/kotlin/com/example/websocketgateway/websocket/WebSocketServerPipeLineInitializer.kt
@@ -1,0 +1,27 @@
+package com.example.websocketgateway.websocket
+
+import io.netty.channel.ChannelInitializer
+import io.netty.channel.socket.SocketChannel
+import io.netty.handler.codec.http.HttpObjectAggregator
+import io.netty.handler.codec.http.HttpServerCodec
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler
+import io.netty.handler.timeout.IdleStateHandler
+import java.util.concurrent.TimeUnit
+
+class WebSocketServerPipeLineInitializer() : ChannelInitializer<SocketChannel>() {
+    override fun initChannel(ch: SocketChannel) {
+        val pipeLine = ch.pipeline()
+        pipeLine.addLast(HttpServerCodec())
+        pipeLine.addLast(HttpObjectAggregator(MAX_CONTENT_LENGTH))
+        pipeLine.addLast(WebSocketServerCompressionHandler())
+        pipeLine.addLast(WebSocketServerProtocolHandler(WEBSOCKET_PATH, null, true))
+        pipeLine.addLast(IdleStateHandler(60, 30, 0, TimeUnit.SECONDS))
+        pipeLine.addLast(WebSocketHandler())
+    }
+
+    companion object {
+        private const val WEBSOCKET_PATH = "/connect"
+        private const val MAX_CONTENT_LENGTH = 65536
+    }
+}

--- a/websocket-gateway/src/main/kotlin/com/example/websocketgateway/websocket/WebSocketServerRunner.kt
+++ b/websocket-gateway/src/main/kotlin/com/example/websocketgateway/websocket/WebSocketServerRunner.kt
@@ -1,0 +1,17 @@
+package com.example.websocketgateway.websocket
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+
+@Component
+class WebSocketServerRunner(
+    @Value("\${server.websocket-port}")
+    private val port: Int,
+) : ApplicationRunner {
+    override fun run(args: ApplicationArguments?) {
+        val webSocketServer = WebSocketServer(port)
+        webSocketServer.start()
+    }
+}

--- a/websocket-gateway/src/main/resources/application.yml
+++ b/websocket-gateway/src/main/resources/application.yml
@@ -4,3 +4,4 @@ spring:
 
 server:
   port: 8081
+  websocket-port: 8000


### PR DESCRIPTION
# DONE
- WebSocket 기본적인 Server 정의
-  Upgrade에 이은 Echo까지 확인 완료

# TODO
- Http서버 구현 > Auth 파트
- Auth파트에서 발급받은 Token을 WebSocket에서 Upgrade시 검증
- HandShakeComplete Event 트리거시 아래와 같은 동작 수행 필요
   - Token검증 실패시 Channel Close
   - Token검증 성공시 ChannelAttribute에 User정보 세팅
- Http서버 요청 시, User정보 항상 포함시켜줘야함 (Http서버 stateless하게)
- Message 포맷 정의 필요 
     - 전문같이 개별부 공통부??
        - 모든 파싱은 HTTP?
             - WebSocket 서버에 로직들어가는 것 최소화 가능
             - 메세지 해석의 책임은  Http서버로 넘어가기 떄문에 단일 Endpint를 가지게 됨
        - 공통부 파싱은 WeSocket에서 하고 Endpint 분기?
              - Endpoint 구분 가능
              - 공통부 변경시 WebSocket 서버 재배포 필요